### PR TITLE
Use version range for logging components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <java.build.version>1.8</java.build.version>
     <java.build.vendor>zulu</java.build.vendor>
+    <logback.base.version>1.2.11</logback.base.version>
+    <logback.range.version>[${logback.base.version},1.2.9999)</logback.range.version>
   </properties>
 
   <modules>
@@ -34,7 +36,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
+      <version>${logback.range.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This commit bumps the version of Logback and shifts to the use of
version ranges for Logback.